### PR TITLE
[SB][105361098] Add optional declustering animation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "2.1.1",
   "main": "marker-clusterer.js",
   "dependencies": {
+    "marker-animate": "https://raw.githubusercontent.com/combatwombat/marker-animate/1a1f75868960bab545315b0725882d61abcd626c/markerAnimate.js"
   },
   "ignore": [
     "package.json",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/105361098

Modify the 3rd-party marker clusterer script (which we have in a rentpath repo presumably for use by bower) adding optional support for animated declustering.

Instructions to try it out locally:
- Pull map.js and ag repos
- In map.js and ag, change to the "sb_105361098_cluster_animation_support" branch
- Run `bower link` in this repo and map.js
- In ag, run `bower link map` and `bower link marker-clusterer`
- Add `pinball=map_variation_one` to a map url. For example: http://local.apartmentguide.com/map?state=Georgia&city=Atlanta&pinball=map_variation_one

Note that the way the feature was added is not very generally reusable as-is. It's rather specific to the AC for the flip (based on zooming or panning such that the total number of markers in the current view is under a threshold, and the rule that at any point we show either all markers or all clusters).
Open to low effort alternatives/suggestions.