### PR TITLE
Replaces dot with dash for RP version separator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "marker-clusterer",
-  "version": "2.1.1.rp.1.0.3",
+  "version": "2.1.1-rp.1.0.3",
   "main": "marker-clusterer.js",
   "dependencies": {
   },

--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
   "author": {
     "name": "Luke Mahe"
   },
-  "repositories": [
-    {
-        "type": "git",
-        "url": "https://github.com/primedia/preserves.git"
-    }
-  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/primedia/preserves.git"
+  },
   "github": "https://github.com/primedia/preserves.git"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marker-clusterer",
-  "version": "2.1.1.rp.1.0.3",
+  "version": "2.1.1-rp.1.0.3",
   "description": "MarkerClusterer for Google Maps v3",
   "homepage": "https://github.com/primedia/preserves",
   "jam": {


### PR DESCRIPTION
`npm install` raises errors for versions containing a dot followed by a
non-numeric character. Subtituting a dash for a dot fits node's required
semver scheme, although it regards it as "pre-release". Given this is
being used internally, it seems an acceptable solution.